### PR TITLE
adjusting autocommit values for NRT needs

### DIFF
--- a/solrconfig.xml
+++ b/solrconfig.xml
@@ -143,12 +143,11 @@
 
   <updateHandler class="solr.DirectUpdateHandler2">
     <autoCommit>
-       <maxDocs>1000000</maxDocs>
-       <maxTime>900000</maxTime>
-       <openSearcher>false</openSearcher>
+       <maxDocs>10000</maxDocs>
+       <maxTime>9000</maxTime>
     </autoCommit>
     <autoSoftCommit>
-      <maxTime>9000000</maxTime>
+      <maxTime>1000</maxTime>
     </autoSoftCommit>
     <commitWithin>
       <softCommit>false</softCommit>


### PR DESCRIPTION
Making PR to get feedback on this.

The emerging requirements for the "Publish" step of combine-replacement DAGs seems to say we need near real time (NRT) searching, since the updated solr collection is almost immediately reviewed by metadata folks for updates to QA the data from that DAG run. I've adjusted some of the settings to try to adjust the solr configs side for this so we have faster, solrcloud-managed commits. Thoughts?